### PR TITLE
Bug fix with Mac OS.

### DIFF
--- a/web_scraping/epic_games_scraper/extract_epic.py
+++ b/web_scraping/epic_games_scraper/extract_epic.py
@@ -40,7 +40,9 @@ def get_listings_from_json(json_str: str) -> list[dict]:
 
 def get_operating_systems(tags: list[dict]):
     """Returns a list of operating systems from a list of tag dicts."""
-    return [tag['name'] for tag in tags if tag.get('groupName') == "platform"]
+    platforms = [tag['name'].replace("MacOS", "Mac")
+                 for tag in tags if tag.get('groupName') == "platform"]
+    return platforms
 
 
 def get_genres(tags: list[dict]):

--- a/web_scraping/epic_games_scraper/extract_epic.py
+++ b/web_scraping/epic_games_scraper/extract_epic.py
@@ -40,7 +40,7 @@ def get_listings_from_json(json_str: str) -> list[dict]:
 
 def get_operating_systems(tags: list[dict]):
     """Returns a list of operating systems from a list of tag dicts."""
-    platforms = [tag['name'].replace("MacOS", "Mac")
+    platforms = [tag['name'].replace("MacOS", "Mac").replace("Mac OS", "Mac")
                  for tag in tags if tag.get('groupName') == "platform"]
     return platforms
 

--- a/web_scraping/epic_games_scraper/test_extract_epic.py
+++ b/web_scraping/epic_games_scraper/test_extract_epic.py
@@ -78,11 +78,11 @@ def test_format_release_date(input_date, expected_output):
 @pytest.mark.parametrize("input_tags, expected_output", [
     ([{"name": "Windows", "groupName": "platform"},
       {"name": "Linux", "groupName": "platform"},
-      {"name": "MacOS", "groupName": "platform"}], ["Windows", "Linux", "MacOS"]),
+      {"name": "MacOS", "groupName": "platform"}], ["Windows", "Linux", "Mac"]),
     ([{"name": "Windows", "groupName": "platform"},
       {"name": "Ubuntu", "groupName": "Linux"},
       {"name": "MacOS", "groupName": "platform"},
-      {"name": "iOS", "groupName": "platform"}], ["Windows", "MacOS", "iOS"]),
+      {"name": "iOS", "groupName": "platform"}], ["Windows", "Mac", "iOS"]),
     ([{"name": "Ubuntu", "groupName": "Linux"},
       {"name": "iOS", "groupName": "mobile"}], []),
     ([], []),


### PR DESCRIPTION
All instances of "MacOS" in the Epic scraper are now replaced with "Mac" to be compliant with the database.